### PR TITLE
[WIP] Day/Night mode from latest appcompat update

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme.DayNight">
 
         <activity android:name=".activity.MainActivity">
             <intent-filter>

--- a/app/src/main/java/com/sourceallies/android/zonebeacon/ZoneBeaconApplication.java
+++ b/app/src/main/java/com/sourceallies/android/zonebeacon/ZoneBeaconApplication.java
@@ -17,6 +17,8 @@
 package com.sourceallies.android.zonebeacon;
 
 import android.app.Application;
+import android.app.UiModeManager;
+import android.content.Context;
 import android.support.v7.app.AppCompatDelegate;
 
 /**
@@ -24,11 +26,16 @@ import android.support.v7.app.AppCompatDelegate;
  * other things that need to be active app-wide.
  */
 public class ZoneBeaconApplication extends Application {
+    static {
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+    }
 
     @Override
     public void onCreate() {
         super.onCreate();
-        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+
+        UiModeManager uiManager = (UiModeManager) getSystemService(Context.UI_MODE_SERVICE);
+        uiManager.setNightMode(UiModeManager.MODE_NIGHT_AUTO);
     }
 
 }

--- a/app/src/main/res/layout/adapter_item_button_zone.xml
+++ b/app/src/main/res/layout/adapter_item_button_zone.xml
@@ -4,7 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@android:color/white">
+    android:background="?list_item_background">
 
     <TextView
         android:id="@+id/title"
@@ -19,6 +19,6 @@
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="@color/black_divider"/>
+        android:background="?list_item_divider"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/adapter_item_button_zone_header.xml
+++ b/app/src/main/res/layout/adapter_item_button_zone_header.xml
@@ -12,13 +12,12 @@
         android:layout_height="wrap_content"
         android:padding="16dp"
         android:textSize="16sp"
-        android:fontFamily="sans-serif-light"
-        android:textColor="@color/black_semi_transparent" />
+        android:fontFamily="sans-serif-light" />
 
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="@color/black_divider"/>
+        android:background="?list_item_divider"/>
 
 </LinearLayout>
 

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme.DayNight" parent="AppTheme">
+        <item name="list_item_background">@android:color/black</item>
+        <item name="list_item_divider">@color/white_divider</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/attr.xml
+++ b/app/src/main/res/values/attr.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="list_item_background" format="color"/>
+    <attr name="list_item_divider" format="color"/>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -23,7 +23,10 @@
     <color name="colorAccentDark">#FF9100</color>
 
     <color name="black_semi_transparent">#B2000000</color>
+    <color name="white_semi_transparent">#B2FFFFFF</color>
     <color name="black_divider">#05000000</color>
+    <color name="white_divider">#05FFFFFF</color>
+
     <color name="white">#fafafa</color>
     <color name="white_pressed">#f1f1f1</color>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,6 +16,11 @@
 
 <resources>
 
+    <style name="AppTheme.DayNight" parent="AppTheme">
+        <item name="list_item_background">@android:color/white</item>
+        <item name="list_item_divider">@color/black_divider</item>
+    </style>
+
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
This should in theory allow the app to display in both day and night mode depending on the time of day. It is not currently working for unknown reasons though and will always display the day theme.

For testing, you can change `AppCompatDelegate.MODE_NIGHT_AUTO` in `ZoneBeaconApplication` to `AppCompatDelegate.MODE_NIGHT_YES` and that should enable night mode. But it doesn't. 

@klinker24 any ideas?
