### PR TITLE
[WIP] Allow the user to edit items within a gateway

### DIFF
--- a/app/src/main/java/com/sourceallies/android/zonebeacon/activity/GatewayItemEditorActivity.java
+++ b/app/src/main/java/com/sourceallies/android/zonebeacon/activity/GatewayItemEditorActivity.java
@@ -61,6 +61,7 @@ public class GatewayItemEditorActivity extends RoboAppCompatActivity {
         setSupportActionBar(toolbar);
         setTitle(getString(R.string.edit_gateway_information));
 
+        addAdapter();
 
     }
 

--- a/app/src/main/res/layout/activity_gateway_item_editor.xml
+++ b/app/src/main/res/layout/activity_gateway_item_editor.xml
@@ -38,68 +38,12 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_gravity="top"
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:paddingTop="60dp"
-        android:layout_height="wrap_content">
-
-        <LinearLayout
-            android:layout_width="230dp"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:layout_gravity="center">
-
-            <android.support.design.widget.TextInputLayout
-                android:id="@+id/name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <EditText
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textCapWords|textAutoCorrect"
-                    android:hint="@string/name" />
-            </android.support.design.widget.TextInputLayout>
-
-            <android.support.design.widget.TextInputLayout
-                android:id="@+id/ip_address"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <EditText
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textUri"
-                    android:hint="@string/ip_address" />
-            </android.support.design.widget.TextInputLayout>
-
-            <android.support.design.widget.TextInputLayout
-                android:id="@+id/port"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <EditText
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:inputType="number"
-                    android:singleLine="true"
-                    android:hint="@string/port" />
-            </android.support.design.widget.TextInputLayout>
-
-        </LinearLayout>
-
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clipToPadding="true"
-            android:layout_marginTop="?android:actionBarSize"
-            android:saveEnabled="false" />
-    </LinearLayout>
+        android:layout_height="match_parent"
+        android:clipToPadding="true"
+        android:layout_marginTop="?android:actionBarSize"
+        android:saveEnabled="false" />
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Start working on https://github.com/jacobklinker/zonebeacon/issues/9

I have created an adapter that will display all the editable items within a zone.

Right now, clicking items won't do anything and the adapter is never used. We should create a new activity (based on the `RecyclerView` capabilities contained in the `MainActivity`) and use this adapter on it. 

Clicking an item will redirect to the correct creation screen with the info filled out.
